### PR TITLE
Add workflow service

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "workflow-service"]
+	path = workflow-service
+	url = https://github.com/jaeddy/workflow-service


### PR DESCRIPTION
Uses jaeddy/workflow-service to provide a local copy of `wes_service` and `wes_client` modules.