### PR TITLE
Add Dockstore verifier

### DIFF
--- a/wfinterop/trs/verifier/dockstore_verifier.json
+++ b/wfinterop/trs/verifier/dockstore_verifier.json
@@ -1,0 +1,154 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "description": "This describes the dockstore API, a webservice that manages pairs of Docker images and associated metadata such as CWL documents and Dockerfiles used to build those images",
+    "version": "1.5.1",
+    "title": "Dockstore API",
+    "termsOfService": "TBD",
+    "contact": {
+      "name": "Dockstore@ga4gh",
+      "url": "https://github.com/ga4gh/dockstore",
+      "email": "theglobalalliance@genomicsandhealth.org"
+    },
+    "license": {
+      "name": "Apache License Version 2.0",
+      "url": "https://github.com/ga4gh/dockstore/blob/develop/LICENSE"
+    }
+  },
+  "host": "dockstore.org",
+  "basePath": "/api/",
+  "tags": [
+    {
+      "name": "extendedGA4GH",
+      "description": "Optional experimental extensions of the GA4GH API"
+    }
+  ],
+  "schemes": [
+    "https"
+  ],
+  "paths": {
+    "/api/ga4gh/v2/extended/{id}/versions/{version_id}/{type}/tests/{relative_path}": {
+      "post": {
+        "tags": [
+          "extendedGA4GH"
+        ],
+        "summary": "Annotate test JSON with information on whether it ran successfully on particular platforms plus metadata",
+        "description": "Test JSON can be annotated with whether they ran correctly keyed by platform and associated with some metadata ",
+        "operationId": "toolsIdVersionsVersionIdTypeTestsPost",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "type",
+            "in": "path",
+            "description": "The type of the underlying descriptor. Allowable values include \"CWL\", \"WDL\", \"NFL\".",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "A unique identifier of the tool, scoped to this registry, for example `123456`",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "version_id",
+            "in": "path",
+            "description": "An identifier of the tool version for this particular tool registry, for example `v1`",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "relative_path",
+            "in": "path",
+            "description": "A relative path to the test json as retrieved from the files endpoint or the tests endpoint",
+            "required": true,
+            "type": "string",
+            "pattern": ".+"
+          },
+          {
+            "name": "platform",
+            "in": "query",
+            "description": "Platform to report on",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "verified",
+            "in": "query",
+            "description": "Verification status, omit to delete key",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "name": "metadata",
+            "in": "query",
+            "description": "Additional information on the verification (notes, explanation)",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The tool test JSON response.",
+            "schema": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "object"
+              }
+            }
+          },
+          "401": {
+            "description": "Credentials not provided or incorrect",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "404": {
+            "description": "The tool test cannot be found to annotate.",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        },
+        "security": [
+          {
+            "BEARER": []
+          }
+        ]
+      }
+    }
+  },
+  "securityDefinitions": {
+    "BEARER": {
+      "type": "apiKey",
+      "name": "Authorization",
+      "in": "header"
+    }
+  },
+  "definitions": {
+
+    "Error": {
+      "type": "object",
+      "required": [
+        "code"
+      ],
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        }
+      }
+    }
+
+  },
+  "externalDocs": {
+    "description": "Dockstore documentation",
+    "url": "https://www.dockstore.org/docs/getting-started"
+  }
+}

--- a/wfinterop/trs/verifier/verify_from_basel.py
+++ b/wfinterop/trs/verifier/verify_from_basel.py
@@ -1,0 +1,109 @@
+import json
+
+from bravado.client import SwaggerClient
+from bravado.requests_client import RequestsClient
+
+# Your Dockstore token (need to be a Dockstore curator, contact Dockstore team to become one)
+curator_token = ""
+# The Dockstore hostname(production Dockstore would be "dockstore.org")
+hostname = "dockstore.org"
+http_client = RequestsClient()
+http_client.set_api_key(hostname, "Bearer " + curator_token, param_name="Authorization",
+                        param_in="header")
+# dockstore_verifier.json is a stripped down version of the Dockstore swagger.json that only has the one verification endpoint
+with open('dockstore_verifier.json', 'r') as f:
+    distros_dict = json.load(f)
+client = SwaggerClient.from_spec(distros_dict, http_client=http_client)
+
+# metadata will be renamed the the future as "verifier" or similar
+response = client.extendedGA4GH.toolsIdVersionsVersionIdTypeTestsPost(type="CWL",
+                                                                      id="#workflow/github.com/dockstore-testing/md5sum-checker",
+                                                                      version_id="develop",
+                                                                      relative_path="md5sum-input-cwl.json",
+                                                                      platform="Arvados", verified=True,
+                                                                      metadata="AGHA via Veritas").response().result
+print response
+response = client.extendedGA4GH.toolsIdVersionsVersionIdTypeTestsPost(type="WDL",
+                                                                      id="#workflow/github.com/dockstore-testing/md5sum-checker/wdl",
+                                                                      version_id="develop",
+                                                                      relative_path="md5sum-wdl.json",
+                                                                      platform="Cromwell",
+                                                                      metadata="TopMed, HCA via Broad",
+                                                                      verified=True).response().result
+print response
+response = client.extendedGA4GH.toolsIdVersionsVersionIdTypeTestsPost(type="WDL",
+                                                                      id="#workflow/github.com/dockstore-testing/md5sum-checker/wdl",
+                                                                      version_id="develop",
+                                                                      relative_path="md5sum-wdl.json", platform="Cromwell",
+                                                                      metadata="GEL, AGHA via Illumina", verified=True).response().result
+print response
+response = client.extendedGA4GH.toolsIdVersionsVersionIdTypeTestsPost(type="WDL",
+                                                                      id="#workflow/github.com/HumanCellAtlas/skylab/HCA_SmartSeq2",
+                                                                      version_id="dockstore",
+                                                                      relative_path="../../test/smartseq2_single_sample/pr/dockstore_test_inputs.json",
+                                                                      platform="Cromwell",
+                                                                      metadata="HCA via CZI", verified=True).response().result
+print response
+response = client.extendedGA4GH.toolsIdVersionsVersionIdTypeTestsPost(type="CWL",
+                                                                      id="#workflow/github.com/DataBiosphere/topmed-workflows/TOPMed_alignment_pipeline_CWL",
+                                                                      version_id="1.31.0",
+                                                                      relative_path="topmed-alignment.sample.json",
+                                                                      platform="Arvados",
+                                                                      metadata="AGHA via Veritas", verified=True).response().result
+print response
+response = client.extendedGA4GH.toolsIdVersionsVersionIdTypeTestsPost(type="WDL",
+                                                                      id="#workflow/github.com/DataBiosphere/topmed-workflows/u_of_Michigan_alignment_pipeline",
+                                                                      version_id="1.29.0",
+                                                                      relative_path="u_of_michigan_aligner.json",
+                                                                      platform="Cromwell",
+                                                                      metadata="HCA via CZI", verified=True).response().result
+print response
+response = client.extendedGA4GH.toolsIdVersionsVersionIdTypeTestsPost(type="WDL",
+                                                                      id="#workflow/github.com/DataBiosphere/topmed-workflows/u_of_Michigan_alignment_pipeline",
+                                                                      version_id="1.29.0",
+                                                                      relative_path="u_of_michigan_aligner.json",
+                                                                      platform="Cromwell",
+                                                                      metadata="TOPMed, HCA via Broad", verified=True).response().result
+print response
+response = client.extendedGA4GH.toolsIdVersionsVersionIdTypeTestsPost(type="WDL",
+                                                                      id="#workflow/github.com/DataBiosphere/topmed-workflows/u_of_Michigan_alignment_pipeline",
+                                                                      version_id="1.29.0",
+                                                                      relative_path="u_of_michigan_aligner.json",
+                                                                      platform="Cromwell",
+                                                                      metadata="GEL, AGHA via Illumina", verified=True).response().result
+print response
+response = client.extendedGA4GH.toolsIdVersionsVersionIdTypeTestsPost(type="WDL",
+                                                                      id="#workflow/github.com/DataBiosphere/topmed-workflows/u_of_Michigan_alignment_pipeline",
+                                                                      version_id="1.31.0",
+                                                                      relative_path="u_of_michigan_aligner.json",
+                                                                      platform="Cromwell",
+                                                                      metadata="HCA via CZI", verified=True).response().result
+print response
+response = client.extendedGA4GH.toolsIdVersionsVersionIdTypeTestsPost(type="WDL",
+                                                                      id="#workflow/github.com/DataBiosphere/topmed-workflows/TopMed_Variant_Caller",
+                                                                      version_id="1.29.0",
+                                                                      relative_path="topmed_freeze3_calling.json",
+                                                                      platform="Cromwell",
+                                                                      metadata="TOPMed, HCA via Broad", verified=True).response().result
+print response
+response = client.extendedGA4GH.toolsIdVersionsVersionIdTypeTestsPost(type="WDL",
+                                                                      id="#workflow/github.com/DataBiosphere/topmed-workflows/TopMed_Variant_Caller",
+                                                                      version_id="1.29.0",
+                                                                      relative_path="topmed_freeze3_calling.json",
+                                                                      platform="Cromwell",
+                                                                      metadata="GEL, AGHA via Illumina", verified=True).response().result
+print response
+response = client.extendedGA4GH.toolsIdVersionsVersionIdTypeTestsPost(type="CWL",
+                                                                      id="quay.io/pancancer/pcawg-bwa-mem-workflow",
+                                                                      version_id="checker",
+                                                                      relative_path="Dockstore_cwl.json",
+                                                                      platform="Arvados",
+                                                                      metadata="AGHA via Veritas", verified=True).response().result
+print response
+response = client.extendedGA4GH.toolsIdVersionsVersionIdTypeTestsPost(type="CWL",
+                                                                      id="#workflow/github.com/bcbio/bcbio_validation_workflows/wes-agha-test-arvados",
+                                                                      version_id="master",
+                                                                      relative_path="main-wes_chr21_test-samples.json",
+                                                                      platform="Arvados",
+                                                                      metadata="AGHA via Veritas", verified=True).response().result
+print response


### PR DESCRIPTION
This adds:
- the Dockstore verification swagger.json that can be used with Bravado 
- a sample script that demonstrates how it can be used (in this case, verifying the results from Basel)

This should be moved around as needed in order to be integrated with the rest of the workflow interop (verify after successful response from WES).