### PR TITLE
Add placeholder controllers

### DIFF
--- a/ga4ghtest/core/controllers/apis_controller.py
+++ b/ga4ghtest/core/controllers/apis_controller.py
@@ -1,0 +1,21 @@
+
+
+def get_apis(
+    sort_by='created_at',
+    order='desc',
+    limit=3
+):  # noqa: E501
+    """Get APIs
+
+    Get the list of available APIs.  # noqa: E501
+
+    :param sort_by: logic by which to sort matched records
+    :type sort_by: str
+    :param order: sort order (ascending or descending)
+    :type order: str
+    :param limit: maximum number of records to return
+    :type limit: int
+
+    :rtype: str
+    """
+    return 'Not Implemented', 501

--- a/ga4ghtest/core/controllers/plugins_controller.py
+++ b/ga4ghtest/core/controllers/plugins_controller.py
@@ -1,0 +1,37 @@
+from ga4ghtest.core.models.plugin import Plugin
+
+
+def create_plugin(
+    body
+):  # noqa: E501
+    """Create a test plugin
+
+    Add a plugin for testing functionality of an API. # noqa: E501
+
+    :param body: 
+    :type body: dict | bytes
+
+    :rtype: str
+    """
+    return 'Not Implemented', 501
+
+
+def get_plugins(
+    sort_by='created_at',
+    order='desc',
+    limit=3
+):  # noqa: E501
+    """Get test plugins
+
+    Get the list of available test plugins.  # noqa: E501
+
+    :param sort_by: logic by which to sort matched records
+    :type sort_by: str
+    :param order: sort order (ascending or descending)
+    :type order: str
+    :param limit: maximum number of records to return
+    :type limit: int
+
+    :rtype: str
+    """
+    return 'Not Implemented', 501

--- a/ga4ghtest/core/controllers/servers_controller.py
+++ b/ga4ghtest/core/controllers/servers_controller.py
@@ -1,0 +1,37 @@
+from ga4ghtest.core.models.server import Server
+
+
+def get_servers(
+    sort_by='created_at',
+    order='desc',
+    limit=3
+):  # noqa: E501
+    """Get target servers
+
+    Get the list of available servers.  # noqa: E501
+
+    :param sort_by: logic by which to sort matched records
+    :type sort_by: str
+    :param order: sort order (ascending or descending)
+    :type order: str
+    :param limit: maximum number of records to return
+    :type limit: int
+
+    :rtype: str
+    """
+    return 'Not Implemented', 501
+
+
+def register_server(
+    body
+):  # noqa: E501
+    """Register a server
+
+    Add an API server to the testbed. # noqa: E501
+
+    :param body: 
+    :type body: dict | bytes
+
+    :rtype: str
+    """
+    return 'Not Implemented', 501

--- a/ga4ghtest/core/controllers/tests_controller.py
+++ b/ga4ghtest/core/controllers/tests_controller.py
@@ -1,0 +1,52 @@
+from ga4ghtest.core.models.service_test import ServiceTest
+
+
+def create_test(
+    body
+):  # noqa: E501
+    """Create a new test
+
+    Create a new plugin run, either right now or with a schedule. # noqa: E501
+
+    :param body: 
+    :type body: dict | bytes
+
+    :rtype: str
+    """
+    return 'Not Implemented', 501
+
+
+def get_test_by_id(
+    test_id
+):  # noqa: E501
+    """Get tests
+
+    Get the status of a given test run.  # noqa: E501
+
+    :param test_id: test ID
+    :type test_id: str
+
+    :rtype: ServiceTest
+    """
+    return 'Not Implemented', 501
+
+
+def get_tests(
+    sort_by='created_at',
+    order='desc',
+    limit=3
+):  # noqa: E501
+    """Get tests
+
+    Get the list of running or scheduled tests.  # noqa: E501
+
+    :param sort_by: logic by which to sort matched records
+    :type sort_by: str
+    :param order: sort order (ascending or descending)
+    :type order: str
+    :param limit: maximum number of records to return
+    :type limit: int
+
+    :rtype: List[ServiceTest]
+    """
+    return 'Not Implemented', 501

--- a/ga4ghtest/openapi/util.py
+++ b/ga4ghtest/openapi/util.py
@@ -23,10 +23,10 @@ def _deserialize(data, klass):
         return deserialize_date(data)
     elif klass == datetime.datetime:
         return deserialize_datetime(data)
-    elif type(klass) == typing.GenericMeta:
-        if klass.__extra__ == list:
+    elif hasattr(klass, '__origin__'):
+        if klass.__origin__ == list:
             return _deserialize_list(data, klass.__args__[0])
-        if klass.__extra__ == dict:
+        if klass.__origin__ == dict:
             return _deserialize_dict(data, klass.__args__[1])
     else:
         return deserialize_model(data, klass)


### PR DESCRIPTION
These controller modules (that live in `core`) serve as "implementations" of the abstract controllers that are auto-generated from the OpenAPI spec. These just return a `501` response for now, but should eventually be used to interact with the classes in `core.models`.